### PR TITLE
one job set id per cloud per day

### DIFF
--- a/src/main/java/io/armadaproject/jenkins/plugin/ArmadaCloud.java
+++ b/src/main/java/io/armadaproject/jenkins/plugin/ArmadaCloud.java
@@ -126,6 +126,7 @@ public class ArmadaCloud extends Cloud implements PodTemplateGroup {
     private String armadaCredentialsId;
     private String armadaLookoutUrl;
     private String armadaLookoutPort;
+    private String armadaJobSetId;
 
     private String serverUrl;
     private boolean useJenkinsProxy;
@@ -342,6 +343,15 @@ public class ArmadaCloud extends Cloud implements PodTemplateGroup {
     @DataBoundSetter
     public void setArmadaLookoutPort(String armadaLookoutPort) {
         this.armadaLookoutPort = armadaLookoutPort;
+    }
+
+    public String getArmadaJobSetId() {
+        return armadaJobSetId;
+    }
+
+    @DataBoundSetter
+    public void setArmadaJobSetId(String armadaJobSetId) {
+        this.armadaJobSetId = armadaJobSetId;
     }
 
     public String getServerUrl() {

--- a/src/main/java/io/armadaproject/jenkins/plugin/KubernetesLauncher.java
+++ b/src/main/java/io/armadaproject/jenkins/plugin/KubernetesLauncher.java
@@ -48,9 +48,11 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -167,8 +169,15 @@ public class KubernetesLauncher extends JNLPLauncher {
             if (existingJobState == JobState.UNKNOWN) {
                 LOGGER.log(FINE, () -> "Creating job: " + cloudName + "/" + podName);
                 try {
+                    String newArmadaJobSetId =
+                        cloud.getDisplayName() + new SimpleDateFormat("-ddMMyyyy").format(
+                            new Date());
+                    if (!newArmadaJobSetId.equals(cloud.getArmadaJobSetId())) {
+                        cloud.setArmadaJobSetId(newArmadaJobSetId);
+                    }
+
                     ArmadaMapper armadaMapper = new ArmadaMapper(cloud.getArmadaQueue(),
-                        cloud.getArmadaNamespace(), cloud.getArmadaQueue(), pod);
+                        cloud.getArmadaNamespace(), cloud.getArmadaJobSetId(), pod);
 
                     JobSubmitResponse jobSubmitResponse = armadaClient.submitJob(
                         armadaMapper.createJobSubmitRequest());

--- a/src/main/resources/io/armadaproject/jenkins/plugin/ArmadaCloud/config.jelly
+++ b/src/main/resources/io/armadaproject/jenkins/plugin/ArmadaCloud/config.jelly
@@ -52,6 +52,10 @@ THE SOFTWARE.
       <f:textbox default="30000"/>
     </f:entry>
 
+    <f:entry title="${%Armada job set id}" field="armadaJobSetId">
+      <f:textbox/>
+    </f:entry>
+
     <f:validateButton title="${%Test Armada Connection}" progress="${%Testing...}" method="testArmadaConnection" with="armadaUrl,armadaPort,armadaCredentialsId" />
 
     <f:entry title="${%Kubernetes URL}" field="serverUrl">


### PR DESCRIPTION
armada job set id is created when pipeline is run based on current date in format <cloud_name>-ddmmyyyy and saved to cloud. value for job set id is not configurable atm.